### PR TITLE
Add unit test for UnlinkMetadata dial action

### DIFF
--- a/UnlinkAccountRequest/Tests/UnlinkAccountRequest_Tests/UnlinkMetadataTests.swift
+++ b/UnlinkAccountRequest/Tests/UnlinkAccountRequest_Tests/UnlinkMetadataTests.swift
@@ -1,0 +1,28 @@
+import XCTest
+@testable import UnlinkAccountRequest
+
+final class UnlinkMetadataTests: XCTestCase {
+    func testDecodesDialAction() throws {
+        let json = """
+        {
+            "title": "Need help?",
+            "message": "Call us",
+            "action": {
+                "type": "dial",
+                "name": "Call",
+                "data": {
+                    "phone": "123456789"
+                }
+            }
+        }
+        """.data(using: .utf8)!
+
+        let metadata = try JSONDecoder().decode(UnlinkMetadata.self, from: json)
+        XCTAssertEqual(metadata.title, "Need help?")
+        XCTAssertEqual(metadata.message, "Call us")
+        XCTAssertEqual(metadata.action.type, .dial)
+        XCTAssertEqual(metadata.action.name, "Call")
+        XCTAssertEqual(metadata.action.metadata.phone, "123456789")
+    }
+}
+


### PR DESCRIPTION
## Summary
- add decoding test for dial action metadata

## Testing
- `swift test` *(fails: package APIKit not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5e9fd0348832f969e82656503c2e0