### PR TITLE
Add tests for UnlinkMetadata

### DIFF
--- a/UnlinkAccountRequest/Tests/UnlinkAccountRequest_Tests/UnlinkMetadataTests.swift
+++ b/UnlinkAccountRequest/Tests/UnlinkAccountRequest_Tests/UnlinkMetadataTests.swift
@@ -24,5 +24,68 @@ final class UnlinkMetadataTests: XCTestCase {
         XCTAssertEqual(metadata.action.name, "Call")
         XCTAssertEqual(metadata.action.metadata.phone, "123456789")
     }
+
+    func testDecodesURLAction() throws {
+        let json = """
+        {
+            "title": "Visit us",
+            "message": "Open website",
+            "action": {
+                "type": "url",
+                "name": "Website",
+                "data": {
+                    "link": "https://example.com"
+                }
+            }
+        }
+        """.data(using: .utf8)!
+
+        let metadata = try JSONDecoder().decode(UnlinkMetadata.self, from: json)
+        XCTAssertEqual(metadata.title, "Visit us")
+        XCTAssertEqual(metadata.message, "Open website")
+        XCTAssertEqual(metadata.action.type, .url)
+        XCTAssertEqual(metadata.action.name, "Website")
+        XCTAssertEqual(metadata.action.metadata.link, "https://example.com")
+    }
+
+    func testDecodesInvalidActionType() throws {
+        let json = """
+        {
+            "title": "Need help?",
+            "message": "Unknown action",
+            "action": {
+                "type": "whatever",
+                "name": "Invalid",
+                "data": {
+                    "link": "https://example.com"
+                }
+            }
+        }
+        """.data(using: .utf8)!
+
+        let metadata = try JSONDecoder().decode(UnlinkMetadata.self, from: json)
+        XCTAssertEqual(metadata.action.type, .invalid)
+    }
+
+    func testMissingDataThrowsError() throws {
+        let json = """
+        {
+            "title": "Need help?",
+            "message": "No data",
+            "action": {
+                "type": "url",
+                "name": "Website"
+            }
+        }
+        """.data(using: .utf8)!
+
+        XCTAssertThrowsError(try JSONDecoder().decode(UnlinkMetadata.self, from: json)) { error in
+            guard case DecodingError.keyNotFound(let key, _) = error else {
+                XCTFail("Unexpected error type: \(error)")
+                return
+            }
+            XCTAssertEqual(key.stringValue, "data")
+        }
+    }
 }
 


### PR DESCRIPTION
## Summary
- add tests for URL action decoding
- ensure invalid action types map to `.invalid`
- verify missing action data throws decoding error

## Testing
- `swift test` *(fails: the package at '/workspace/GithubGeo/APIKit' cannot be accessed)*

------
https://chatgpt.com/codex/tasks/task_e_68a5ecdf1d78832f8956a3546abba7f0