### PR TITLE
Add tests for UnlinkRequest properties

### DIFF
--- a/UnlinkAccountRequest/Tests/UnlinkAccountRequest_Tests/UnlinkRequestTests.swift
+++ b/UnlinkAccountRequest/Tests/UnlinkAccountRequest_Tests/UnlinkRequestTests.swift
@@ -1,0 +1,15 @@
+import XCTest
+@testable import UnlinkAccountRequest
+
+final class UnlinkRequestTests: XCTestCase {
+    func testUnlinkRequestProperties() {
+        let request = UnlinkRequest.unlink
+        XCTAssertEqual(request.path, "/api/account/unlink")
+        XCTAssertEqual(request.method, .get)
+        XCTAssertNil(request.parameters)
+        XCTAssertTrue(request.authorized)
+        XCTAssertEqual(request.contentType, .applicationJSON)
+        XCTAssertEqual(request.sourceType, .default)
+    }
+}
+


### PR DESCRIPTION
## Summary
- add unit tests confirming `UnlinkRequest.unlink` configuration (path, method, parameters, authorization, content type, and source type)

## Testing
- `swift test` *(fails: the package at '/workspace/GithubGeo/APIKit' cannot be accessed)*

------
https://chatgpt.com/codex/tasks/task_e_68a5ece405f4832faddcd2256ad8333a