### PR TITLE
Add tests for UnlinkAccount execute behavior

### DIFF
--- a/UnlinkAccountRequest/Sources/UnlinkAccountRequest/Configuration/UnlinkAccountRequest.swift
+++ b/UnlinkAccountRequest/Sources/UnlinkAccountRequest/Configuration/UnlinkAccountRequest.swift
@@ -9,10 +9,15 @@ import Foundation
 import APIKit
 
 public class UnlinkAccount: NSObject {
-    let worker: Worker
+    let worker: WorkerProtocol
 
-    public init(apiProvider: AnyAPIProvider<UnlinkRequest> = AnyAPIProvider<UnlinkRequest>(APIProvider<UnlinkRequest>())){
-        worker = Worker(apiProvider: apiProvider)
+    init(worker: WorkerProtocol) {
+        self.worker = worker
+        super.init()
+    }
+
+    public convenience init(apiProvider: AnyAPIProvider<UnlinkRequest> = AnyAPIProvider<UnlinkRequest>(APIProvider<UnlinkRequest>())){
+        self.init(worker: Worker(apiProvider: apiProvider))
     }
 
     public func execute(onCompletion: ((Result<UnlinkResult, Error>) -> Void)?)  {

--- a/UnlinkAccountRequest/Sources/UnlinkAccountRequest/Workers/Worker.swift
+++ b/UnlinkAccountRequest/Sources/UnlinkAccountRequest/Workers/Worker.swift
@@ -8,15 +8,17 @@
 import APIKit
 import UIKit
 
-final class Worker {
+protocol WorkerProtocol {
+    func unlink(onCompletion: ((Result<UnlinkMetadata, Error>) -> Void)?)
+}
+
+final class Worker: WorkerProtocol {
     let serviceProvider: AnyAPIProvider<UnlinkRequest>
 
     init(apiProvider: AnyAPIProvider<UnlinkRequest> = AnyAPIProvider<UnlinkRequest>(APIProvider<UnlinkRequest>())){
         serviceProvider = apiProvider
     }
-}
 
-extension Worker {
     func unlink(onCompletion: ((Result<UnlinkMetadata, Error>) -> Void)?) {
         serviceProvider.perform(.unlink) {
             do {

--- a/UnlinkAccountRequest/Tests/UnlinkAccountRequest_Tests/UnlinkAccountTests.swift
+++ b/UnlinkAccountRequest/Tests/UnlinkAccountRequest_Tests/UnlinkAccountTests.swift
@@ -1,0 +1,72 @@
+import XCTest
+@testable import UnlinkAccountRequest
+
+final class UnlinkAccountTests: XCTestCase {
+
+    private final class WorkerMock: WorkerProtocol {
+        let result: Result<UnlinkMetadata, Error>
+
+        init(result: Result<UnlinkMetadata, Error>) {
+            self.result = result
+        }
+
+        func unlink(onCompletion: ((Result<UnlinkMetadata, Error>) -> Void)?) {
+            onCompletion?(result)
+        }
+    }
+
+    func testExecuteReturnsUnlinkResultOnSuccess() throws {
+        let json = """
+        {
+            "title": "Need help?",
+            "message": "Call us",
+            "action": {
+                "type": "url",
+                "name": "Support",
+                "data": { "link": "https://example.com" }
+            }
+        }
+        """.data(using: .utf8)!
+
+        let metadata = try JSONDecoder().decode(UnlinkMetadata.self, from: json)
+        let unlinkAccount = UnlinkAccount(worker: WorkerMock(result: .success(metadata)))
+
+        let expectation = self.expectation(description: "completion")
+
+        unlinkAccount.execute { result in
+            switch result {
+            case .success(let unlinkResult):
+                XCTAssertEqual(unlinkResult.title, metadata.title)
+                XCTAssertEqual(unlinkResult.message, metadata.message)
+                XCTAssertEqual(unlinkResult.actionTitle, metadata.action.name)
+                XCTAssertEqual(unlinkResult.action.absoluteString, metadata.action.metadata.link!)
+            case .failure(let error):
+                XCTFail("Expected success, got \(error)")
+            }
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 1.0)
+    }
+
+    func testExecutePropagatesWorkerError() {
+        struct SampleError: Error {}
+
+        let unlinkAccount = UnlinkAccount(worker: WorkerMock(result: .failure(SampleError())))
+
+        let expectation = self.expectation(description: "completion")
+
+        unlinkAccount.execute { result in
+            switch result {
+            case .success:
+                XCTFail("Expected failure")
+            case .failure(let error):
+                XCTAssertTrue(error is SampleError)
+            }
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 1.0)
+    }
+}
+


### PR DESCRIPTION
## Summary
- refactor UnlinkAccount to accept injected worker via new WorkerProtocol
- add unit tests ensuring execute maps metadata to UnlinkResult and propagates worker errors

## Testing
- `swift test` *(fails: the package at '/workspace/GithubGeo/APIKit' cannot be accessed)*

------
https://chatgpt.com/codex/tasks/task_e_68a5ece25224832f883536f3613b40d4