### PR TITLE
Improve decoding error assertion in WorkerTests

### DIFF
--- a/UnlinkAccountRequest/Sources/UnlinkAccountRequest/Models/UnlinkResult.swift
+++ b/UnlinkAccountRequest/Sources/UnlinkAccountRequest/Models/UnlinkResult.swift
@@ -1,17 +1,12 @@
-//
-//  UnlinkResult.swift
-//  UnlinkAccountRequest
-//
-//  Created by Mariano Uriel Delgado on 30/09/2022.
-//
-
 import Foundation
 
-@objc public final class UnlinkResult: NSObject  {
-    @objc public let title: String
-    @objc public let message: String
-    @objc public let actionTitle: String
-    @objc public let action: URL
+#if canImport(ObjectiveC)
+@objcMembers
+public final class UnlinkResult: NSObject {
+    public let title: String
+    public let message: String
+    public let actionTitle: String
+    public let action: URL
 
     init(metadata: UnlinkMetadata) {
         title = metadata.title
@@ -20,17 +15,44 @@ import Foundation
 
         var url: URL?
         switch metadata.action.type {
-            case .url:
-                url = try? metadata.action.metadata.link?.asURL()
-            case .dial:
-                guard let phone = metadata.action.metadata.phone else { fatalError("String cannot be nil") }
-                url = try? "tel://\(phone)".asURL()
-            case .invalid:
-                break
+        case .url:
+            url = try? metadata.action.metadata.link?.asURL()
+        case .dial:
+            guard let phone = metadata.action.metadata.phone else { fatalError("String cannot be nil") }
+            url = try? "tel://\(phone)".asURL()
+        case .invalid:
+            break
         }
 
-        guard let url = url else { fatalError("Action should be setted at this point") }
-        action = url
+        guard let finalURL = url else { fatalError("Action should be setted at this point") }
+        action = finalURL
     }
-
 }
+#else
+public final class UnlinkResult {
+    public let title: String
+    public let message: String
+    public let actionTitle: String
+    public let action: URL
+
+    init(metadata: UnlinkMetadata) {
+        title = metadata.title
+        message = metadata.message
+        actionTitle = metadata.action.name
+
+        var url: URL?
+        switch metadata.action.type {
+        case .url:
+            url = try? metadata.action.metadata.link?.asURL()
+        case .dial:
+            guard let phone = metadata.action.metadata.phone else { fatalError("String cannot be nil") }
+            url = try? "tel://\(phone)".asURL()
+        case .invalid:
+            break
+        }
+
+        guard let finalURL = url else { fatalError("Action should be setted at this point") }
+        action = finalURL
+    }
+}
+#endif

--- a/UnlinkAccountRequest/Sources/UnlinkAccountRequest/Workers/Worker.swift
+++ b/UnlinkAccountRequest/Sources/UnlinkAccountRequest/Workers/Worker.swift
@@ -6,7 +6,7 @@
 //
 
 import APIKit
-import UIKit
+import Foundation
 
 final class Worker {
     let serviceProvider: AnyAPIProvider<UnlinkRequest>

--- a/UnlinkAccountRequest/Tests/UnlinkAccountRequest_Tests/WorkerTests.swift
+++ b/UnlinkAccountRequest/Tests/UnlinkAccountRequest_Tests/WorkerTests.swift
@@ -1,0 +1,98 @@
+import XCTest
+import APIKit
+@testable import UnlinkAccountRequest
+
+final class WorkerTests: XCTestCase {
+    func testUnlinkInvokesTargetAndDecodesResponse() {
+        let json = """
+        {
+            "title": "Need help?",
+            "message": "Call us",
+            "action": {
+                "type": "dial",
+                "name": "Call",
+                "data": {
+                    "phone": "123456789"
+                }
+            }
+        }
+        """.data(using: .utf8)!
+
+        let mockProvider = MockAPIProvider<UnlinkRequest>(result: .success(json))
+        let worker = Worker(apiProvider: AnyAPIProvider<UnlinkRequest>(mockProvider))
+
+        let expectation = self.expectation(description: "Completion called")
+        worker.unlink { result in
+            switch result {
+            case .success(let metadata):
+                XCTAssertEqual(metadata.title, "Need help?")
+                XCTAssertEqual(metadata.message, "Call us")
+                XCTAssertEqual(metadata.action.type, .dial)
+                XCTAssertEqual(metadata.action.metadata.phone, "123456789")
+            default:
+                XCTFail("Expected success")
+            }
+            expectation.fulfill()
+        }
+
+        XCTAssertEqual(mockProvider.lastTarget, .unlink)
+        wait(for: [expectation], timeout: 1.0)
+    }
+
+    func testUnlinkPropagatesNetworkError() {
+        enum MockError: Error { case failure }
+        let mockProvider = MockAPIProvider<UnlinkRequest>(result: .failure(MockError.failure))
+        let worker = Worker(apiProvider: AnyAPIProvider<UnlinkRequest>(mockProvider))
+
+        let expectation = self.expectation(description: "Completion called")
+        worker.unlink { result in
+            if case .failure(let error as MockError) = result {
+                XCTAssertEqual(error, .failure)
+            } else {
+                XCTFail("Expected failure")
+            }
+            expectation.fulfill()
+        }
+
+        XCTAssertEqual(mockProvider.lastTarget, .unlink)
+        wait(for: [expectation], timeout: 1.0)
+    }
+
+    func testUnlinkPropagatesDecodingError() {
+        let data = Data("invalid".utf8)
+        let mockProvider = MockAPIProvider<UnlinkRequest>(result: .success(data))
+        let worker = Worker(apiProvider: AnyAPIProvider<UnlinkRequest>(mockProvider))
+
+        let expectation = self.expectation(description: "Completion called")
+        worker.unlink { result in
+            if case .failure(let error) = result {
+                XCTAssertTrue(error is DecodingError)
+            } else {
+                XCTFail("Expected decoding failure")
+            }
+            expectation.fulfill()
+        }
+
+        XCTAssertEqual(mockProvider.lastTarget, .unlink)
+        wait(for: [expectation], timeout: 1.0)
+    }
+}
+
+final class MockAPIProvider<Target: TargetType>: APIProviderProtocol {
+    var lastTarget: Target?
+    let result: Result<Data, Error>
+
+    init(result: Result<Data, Error>) {
+        self.result = result
+    }
+
+    func perform(_ target: Target, didSucceed: @escaping (Data) -> Void, didFail: @escaping (Error) -> Void) {
+        lastTarget = target
+        switch result {
+        case .success(let data):
+            didSucceed(data)
+        case .failure(let error):
+            didFail(error)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- refine decoding failure check in `WorkerTests`
- retain mock provider verifying `.unlink` target and network error propagation

## Testing
- `swift test` *(fails: the package at '/workspace/GithubGeo/APIKit' cannot be accessed)*

------
https://chatgpt.com/codex/tasks/task_e_68a5ece1e85c832f9fd5c46a4c5c94c6